### PR TITLE
Real hostname to patched devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## v1.0.1
+## v1.0.1 (30 June 2022)
 - Now also patched devices will have the real hostname, instead of the default "localhost".
-## v1.0.0
+## v1.0.0 (2 June 2022)
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+## v1.0.1
+- Now also patched devices will have the real hostname, instead of the default "localhost".
+## v1.0.0
+- Initial release

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ npm install hostname-patcher
 ## Use cases
 For some strange reason, `os.hostname()` is always broken if you're using a version of Node.js not officially supported in Windows 7 (v14.x.x and above), so, this module aims to keep it working.
 
-> __News:__ Now the patched hostname will be your real hostname, not "localhost".
+> __News:__ Now also patched devices will have the real hostname, instead of the default "localhost".
 
 ## Don't want to use it? (Worried about adding this?)
 You'll not have any problem using this patch, because it checks if it's needed before doing its work (see [here](https://github.com/Bellisario/hostname-patcher/blob/a5b63802a7d26481cd46846b1c10f327ceb2034f/lib/index.js#L6)).

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ npm install hostname-patcher
 ## Use cases
 For some strange reason, `os.hostname()` is always broken if you're using a version of Node.js not officially supported in Windows 7 (v14.x.x and above), so, this module aims to keep it working.
 
+> __News:__ Now the patched hostname will be your real hostname, not "localhost".
+
 ## Don't want to use it? (Worried about adding this?)
 You'll not have any problem using this patch, because it checks if it's needed before doing its work (see [here](https://github.com/Bellisario/hostname-patcher/blob/a5b63802a7d26481cd46846b1c10f327ceb2034f/lib/index.js#L6)).
 
@@ -33,7 +35,7 @@ const os = require('os');
 // or module using os module
 const { moduleUsingOS } = require('example');
 
-// will output "localhost" if patch, else your real hostname
+// will output your real hostname if patch and if not
 console.log(os.hostname());
 ```
 ### ES6
@@ -46,7 +48,7 @@ import os from 'os';
 // or module using os module
 import { moduleUsingOS } from 'example';
 
-// will output "localhost" if patch, else your real hostname
+// will output your real hostname if patch and if not
 console.log(os.hostname());
 ```
 > All examples available in the [test folder](https://github.com/Bellisario/hostname-patcher/tree/master/test).
@@ -56,5 +58,5 @@ console.log(os.hostname());
 - __Let us know this patch is useful for other modules__
 
 ## For modules builders
-Even if single projects can use this patch singlely, would be great if modules themselves start using it, because it's a lot better for users experience and more practical.\
-I know that this error occurs because these new Node.js versions are not anymore ufficially supported by Windows 7, but still today is a very usable and light OS for a lot people, so, please, keep supporting it, even if the Node.js community (but not everybody) want anymore.
+Even if single projects can use this patch individually, would be great if modules themselves start using it, because it's a lot better for users experience and more practical.\
+I know that this error occurs because these new Node.js versions are not anymore officially supported by Windows 7, but still today is a very usable and light OS for a lot people, so, please, keep supporting it, even if the Node.js community (but not everybody) want anymore.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,13 @@
 //@ts-check
-const { needsPatch } = require('./utils');
+const { needsPatch, getHostname } = require('./utils');
 const os = require('os');
 
 
 if (needsPatch()) {
+    const patchHostname = getHostname();
     /**
      * thanks to @andris9 for his help with this
      * https://github.com/nodemailer/nodemailer/issues/1410#issuecomment-1144628473
      */
-    os.hostname = () => 'localhost';
+    os.hostname = () => patchHostname;
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 //@ts-check
 const os = require('os');
+const execSync = require('child_process').execSync;
 
 /**
  * Detect if patch is needed or not
@@ -14,5 +15,19 @@ const needsPatch = () => {
     }
 }
 
+/**
+ * Get the current hostname using CMD command (not the OS built-in module)
+ * Returns localhost as fallback if the command fails
+ * @returns {string}
+ */
+const getHostname = () => {
+    let result;
+    try {
+        result = execSync('hostname').toString().trim();
+    } catch(e) {
+        result = 'localhost';
+    }
+    return result;
+}
 
-module.exports = { needsPatch };
+module.exports = { needsPatch, getHostname };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hostname-patcher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Patches os.hostname() for Windows 7 devices using a not officially Node.js supported version",
   "keywords": [
     "os",
@@ -27,6 +27,6 @@
   "license": "MIT",
   "devDependencies": {
     "@jsdevtools/npm-publish": "^1.4.3",
-    "nodemailer": "^6.7.5"
+    "nodemailer": "^6.7.6"
   }
 }

--- a/test/Common.js/index.js
+++ b/test/Common.js/index.js
@@ -3,5 +3,5 @@ require('../../lib/index');
 // then os
 const os = require('os');
 
-// will output "localhost" if patch, else your real hostname
+// will output your real hostname if patch and if not
 console.log(os.hostname());

--- a/test/ES6/index.mjs
+++ b/test/ES6/index.mjs
@@ -3,5 +3,5 @@ import '../../lib/index';
 // then os
 import os from 'os';
 
-// will output "localhost" if patch, else your real hostname
+// will output your real hostname if patch and if not
 console.log(os.hostname());


### PR DESCRIPTION
This pull makes sure also patched devices will have their real hostname instead of the default "localhost", using the built-in CMD command `hostname`.